### PR TITLE
LazyData setting should be returned in DESCRIPTION file.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,6 @@ Description: An example package for collaboartion experiance.
 License: BSD_2_clause + file LICENSE
 URL: https://github.com/sktivd/collab_example
 BugReports: https://github.com/sktivd/collab_example/issues
+LazyData: true
 Suggests: testthat, roxygen2
 RoxygenNote: 6.0.1


### PR DESCRIPTION
LazyData setting in DESCRIPTION file had been disappeared under several updates.
LazyData setting allows loading data when data() is explicitly called after library() was called.